### PR TITLE
Dynamic table size updates

### DIFF
--- a/fuzz/fuzz.ml
+++ b/fuzz/fuzz.ml
@@ -18,13 +18,13 @@ let encode encoder headers =
   List.iter (Encoder.encode_header encoder t) headers;
   Faraday.serialize_to_string t
 
-let test_decode capacity s =
-  let decoder = Decoder.create capacity in
+let test_decode max_size_limit s =
+  let decoder = Decoder.create ~max_size_limit () in
   decode decoder s |> ignore
 
-let test_roundtrip capacity headers =
-  let encoder = Encoder.create capacity in
-  let decoder = Decoder.create capacity in
+let test_roundtrip max_size headers =
+  let encoder = Encoder.create ~max_size () in
+  let decoder = Decoder.create ~max_size_limit:max_size () in
   let s = encode encoder headers in
   match decode decoder s with
   | Ok headers' -> check_eq ~pp:(pp_list pp_header) headers headers'

--- a/src/decoder.mli
+++ b/src/decoder.mli
@@ -2,16 +2,18 @@ open S
 
 type t
 
-val create : int -> t
-(** [create capacity] intializes a decoder with a dynamic table with maximal
-    size [capacity]. This size is an approximation of the memory usage in
-    bytes. *)
-
-val set_capacity : t -> int -> unit
-(** [set_capacity decoder capacity] updates the capacity of the dynamic table. *)
+val create : ?max_size_limit:int -> unit -> t
+(** [create ~max_size_limit ()] intializes a decoder with a dynamic table with
+    maximum size [max_size_limit]. The default is 4096. Each different
+    should be communicated to the encoder by the protocol. *)
 
 val header : t -> header Angstrom.t
 (** A parser for one header *)
 
 val headers : t -> header list Angstrom.t
-(** A parser for headers *)
+(** A parser for one header block *)
+
+val change_table_size_limit : t -> int -> unit
+(** [change_table_size_limit decoder max_size_limit] limits the maximum size of
+    the dynamic table. This limit should be communicated to the encoder by the
+    protocol, and can only change between header blocks. *)

--- a/src/encoder.mli
+++ b/src/encoder.mli
@@ -2,10 +2,16 @@ open S
 
 type t
 
-val create : int -> t
-(** [create capacity] intializes an encoder with a dynamic table with maximal
-    size [capacity]. This size is an approximation of the memory usage in
-    bytes. *)
+val create : ?max_size:int -> unit -> t
+(** [create ~max_size ()] intializes an encoder with a dynamic table with
+    maximum size [max_size]. The default is 4096. The chosen size must be lower
+    than or equal to the maximum set by the protocol. *)
 
 val encode_header : t -> Faraday.t -> header -> unit
 (** [encode_header encoder t header] writes the encoding of [header] to [t] *)
+
+val change_table_size : t -> int -> unit
+(** [change_table_size encoder max_size] changes the maximum size of the dynamic
+    table. This should only occur between header blocks, and is signaled in a
+    dynamic table size update before the next encoded header. The chosen size
+    must stay lower than or equal to the maximum set by the protocol. *)


### PR DESCRIPTION
Table size updates were not implemented completely yet, and what was implemented was wrong (I cheated the tests by setting the initial table size high enough).

It relies on the http2 implementation to call the `change_table_size` functions only between header blocks. It does currently accept encoded table size updates in the middle of header blocks. That shouldn't happen according to the specification, but it doesn't say it's a decoding error either.

@anmonteiro The interaction with the http2 protocol is rather tricky, but I think I got it right now.