### PR TITLE
Add max_field_size

### DIFF
--- a/src/decoder.mli
+++ b/src/decoder.mli
@@ -2,10 +2,14 @@ open S
 
 type t
 
-val create : ?max_size_limit:int -> unit -> t
+val create : ?max_size_limit:int -> ?max_field_size:int -> unit -> t
 (** [create ~max_size_limit ()] intializes a decoder with a dynamic table with
-    maximum size [max_size_limit]. The default is 4096. Each different
-    should be communicated to the encoder by the protocol. *)
+    maximum size [max_size_limit]. The default is 4096. Each other value should
+    be communicated to the encoder by the protocol.
+
+    [max_field_size] is the maximum allowed size in bytes of one name or value
+    field. The default is 4096.
+*)
 
 val header : t -> header Angstrom.t
 (** A parser for one header *)


### PR DESCRIPTION
Limits the size of header fields, as recommended in [RFC7541§7.4](https://httpwg.org/specs/rfc7541.html#rfc.section.7.4).

The default value in [nghttp2](https://github.com/nghttp2/nghttp2/blob/4aac05e1936ad14d66b994b789ab0abe0354a28c/lib/nghttp2_hd.h#L45) is 65536, but most servers use lower values (https://stackoverflow.com/questions/686217/maximum-on-http-header-values).