### PR TITLE
Fix parsing of table size updates

### DIFF
--- a/src/decoder.mli
+++ b/src/decoder.mli
@@ -9,7 +9,7 @@ val create : ?max_size_limit:int -> ?max_field_size:int -> unit -> t
     field. The default is 4096.
 *)
 
-val header : t -> Header.t Angstrom.t
+val header : t -> Header.t option Angstrom.t
 (** A parser for one header *)
 
 val headers : t -> Header.t list Angstrom.t


### PR DESCRIPTION
When a table size update was not followed by a header, it resulted in a parsing failure. I fixed it by letting `Decoder.header` return a `Header.t option`, which is `None` if there are only table size updates in the input.

This situation can occur in:
- A header block that contains only table size updates without headers
  Empty header lists are allowed in theory, although they are probably never used.
- A non-empty header block that ends with a table size update
  It's unclear from the rfc whether table size updates in other places than the beginning of a header block are allowed, but most implementations do not support it and h2spec rejects it.